### PR TITLE
Update RTTrP_Reader.py

### DIFF
--- a/RTTrP_Reader.py
+++ b/RTTrP_Reader.py
@@ -2,7 +2,7 @@ import socket
 import binascii
 import struct
 import thirdParty_motion
-import thirdPart_lighting
+import thirdParty_lighting
 import traceback
 
 def openConnection(IP, PORT, isReading, outModules):

--- a/RTTrP_Reader.py
+++ b/RTTrP_Reader.py
@@ -77,6 +77,7 @@ def openConnection(IP, PORT, isReading, outModules):
 							else:
 								# unknwon packet type, da fuq is this
 								exit()
+						pkt.data = pkt.data[pkt.trackable.size:] # otherwise RTTrPM gets fed the same module again and again!!		
 				elif (hex(pkt.fltHeader) == "0x4434" or hex(pkt.fltHeader) == "0x3444"): # TODO: Create the RTTrPL code that reads an RTTrPL packet
 					pkt = RTTrPL(pkt)
 					sock.close()


### PR DESCRIPTION
Until now the same packet data is forwarded to thirdParty_motion.Trackable() but it needs to be shifted to the next module. My change takes the module length and redacts its data form the packet beginning so that the next module is fed "in pole position" into thirdParty_motion.Trackable()